### PR TITLE
Update tablet_support_title to be consistent with other titles

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,6 @@
     <string name="more_information">More information</string>
     <string name="submit_confirmation">I confirm that the information I have entered is accurate</string>
     <string name="please_confirm_the_information">Please confirm that the information you have entered is accurate</string>
-    <string name="tablet_support_title">This app is not made for tablets.</string>
+    <string name="tablet_support_title">This app is not made for tablets</string>
     <string name="tablet_support_description">This app is only available for smartphones because the app is only effective if you have it on a device that is with you all the time when you go out. Please install the app on your smartphone.</string>
 </resources>


### PR DESCRIPTION
Only a tiny consistency fix.

Most activity titles have either a question mark or no ending punctuation, but the tablet edge case activity title ended with a full stop.